### PR TITLE
Exclude transitive deps

### DIFF
--- a/src/main/groovy/io/gatling/frontline/gradle/FrontLineShadowJar.groovy
+++ b/src/main/groovy/io/gatling/frontline/gradle/FrontLineShadowJar.groovy
@@ -1,7 +1,6 @@
 package io.gatling.frontline.gradle
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.FileCollection
@@ -11,8 +10,6 @@ import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 class FrontLineShadowJar extends ShadowJar {
-
-    private static final DependencyId NETTY_ALL = new DependencyId("io.netty", "netty-all")
 
     private ResolvedConfiguration getResolvedConfiguration() {
         return project.configurations.gatlingCompileClasspath.resolvedConfiguration
@@ -29,40 +26,36 @@ class FrontLineShadowJar extends ShadowJar {
         throw new IllegalArgumentException("Couldn't locate io.gatling:gatling-app in dependencies")
     }
 
-    private void treeToSet(ResolvedDependency dep, Set<DependencyId> acc) {
-        def id = dep.module.id
-        acc.add(new DependencyId(id.group, id.name))
+    private void collectDepAndChildren(ResolvedDependency dep, Set<ResolvedDependency> acc) {
+        acc.add(dep)
         for (child in dep.children) {
-            treeToSet(child, acc)
+            collectDepAndChildren(child, acc)
         }
     }
 
-    private void collectGatlingDepsRec(Set<ResolvedDependency> deps, Set<DependencyId> acc) {
+    private void collectGatlingDepsRec(Set<ResolvedDependency> deps, Set<ResolvedDependency> acc) {
         for (dep in deps) {
             if (dep?.module?.id?.group in ["io.gatling", "io.gatling.highcharts", "io.gatling.frontline"]) {
-                treeToSet(dep, acc)
+                collectDepAndChildren(dep, acc)
+            } else if (dep?.module?.id?.group == "io.netty" && dep?.module?.id?.name == "netty-all") {
+                acc.add(dep)
             } else {
                 collectGatlingDepsRec(dep.children, acc)
             }
         }
     }
 
-    private static boolean excludeDep(ModuleIdentifier moduleIdentifier, Set<DependencyId> gatlingDependencies) {
-        def dependency = new DependencyId(moduleIdentifier.group, moduleIdentifier.name)
-        dependency == NETTY_ALL || gatlingDependencies.contains(dependency)
-    }
-
     @Override
     @Classpath
     FileCollection getIncludedDependencies() {
-        Set<DependencyId> gatlingDependencies = new HashSet<DependencyId>()
-        collectGatlingDepsRec(getResolvedConfiguration().getFirstLevelModuleDependencies(), gatlingDependencies)
+        ResolvedConfiguration resolvedConfiguration = getResolvedConfiguration()
 
-        Set<File> wantedFiles = getResolvedConfiguration().getFiles {
-            !it.hasProperty("module") || !ModuleIdentifier.isInstance(it.module) || !FrontLineShadowJar.excludeDep(it.module, gatlingDependencies)
-        }
+        Set<ResolvedDependency> gatlingDependencies = new HashSet<ResolvedDependency>()
+        collectGatlingDepsRec(resolvedConfiguration.getFirstLevelModuleDependencies(), gatlingDependencies)
 
-        project.files(wantedFiles)
+        project.files(resolvedConfiguration.files) - project.files(gatlingDependencies.collect {
+            it.moduleArtifacts*.file
+        }.flatten())
     }
 
     @TaskAction
@@ -77,41 +70,5 @@ class FrontLineShadowJar extends ShadowJar {
                     "Gatling-Version": gatlingVersion)
         }
         super.copy()
-    }
-
-    private static class DependencyId {
-        private String group
-        private String artifact
-
-        DependencyId(String group, String artifact) {
-            this.group = group
-            this.artifact = artifact
-        }
-
-        @Override
-        boolean equals(o) {
-            if (this.is(o)) return true
-            if (getClass() != o.class) return false
-
-            DependencyId that = (DependencyId) o
-
-            if (artifact != that.artifact) return false
-            if (group != that.group) return false
-
-            return true
-        }
-
-        @Override
-        int hashCode() {
-            int result
-            result = (group != null ? group.hashCode() : 0)
-            result = 31 * result + (artifact != null ? artifact.hashCode() : 0)
-            return result
-        }
-
-        @Override
-        String toString() {
-            return group + ":" + artifact
-        }
     }
 }


### PR DESCRIPTION
Motivation:

Plugin currently only exclude first level module dependencies. We want to exclude all dependencies, including transitive ones.

Modifications:

Have getIncludedDependencies return the diff between all the files and the excludes deps files.

Result:

Correct fatjar when some first level dependency depends on Gatling modules.