### PR TITLE
Target gatlingRuntimeClasspath configuration instead of gatlingCompileClasspath

### DIFF
--- a/src/main/groovy/io/gatling/frontline/gradle/FrontLinePlugin.groovy
+++ b/src/main/groovy/io/gatling/frontline/gradle/FrontLinePlugin.groovy
@@ -25,7 +25,7 @@ class FrontLinePlugin implements Plugin<Project> {
 
         frontLineJar.from(project.sourceSets.gatling.output)
         frontLineJar.configurations = [
-                project.configurations.gatlingCompileClasspath
+                project.configurations.gatlingRuntimeClasspath
         ]
     }
 }

--- a/src/main/groovy/io/gatling/frontline/gradle/FrontLineShadowJar.groovy
+++ b/src/main/groovy/io/gatling/frontline/gradle/FrontLineShadowJar.groovy
@@ -12,7 +12,7 @@ import org.gradle.api.tasks.TaskAction
 class FrontLineShadowJar extends ShadowJar {
 
     private ResolvedConfiguration getResolvedConfiguration() {
-        return project.configurations.gatlingCompileClasspath.resolvedConfiguration
+        project.configurations.gatlingRuntimeClasspath.resolvedConfiguration
     }
 
     private String gatlingVersion() {


### PR DESCRIPTION
Motivation:

Dependencies with runtime scope are not included