### PR TITLE
Exclude files from our fatJar

### DIFF
--- a/src/main/groovy/io/gatling/frontline/gradle/FrontLinePlugin.groovy
+++ b/src/main/groovy/io/gatling/frontline/gradle/FrontLinePlugin.groovy
@@ -21,7 +21,14 @@ class FrontLinePlugin implements Plugin<Project> {
             }
         }
 
-        frontLineJar.exclude("META-INF/versions/*")
+        frontLineJar.exclude(
+          "META-INF/LICENSE",
+          "META-INF/MANIFEST.MF",
+          "META-INF/versions/**",
+          "**/*.SF",
+          "**/*.DSA",
+          "**/*.RSA"
+        )
 
         frontLineJar.from(project.sourceSets.gatling.output)
         frontLineJar.configurations = [


### PR DESCRIPTION
Motivation:
Customers could not use signed dependencies.

Modifications:
 * Exclude somme specific files from the created fat Jar

Result:
Signed jar does not avoid to load customer's simulations