### PR TITLE
Filter out dependencies' maven props

### DIFF
--- a/src/main/groovy/io/gatling/frontline/gradle/FrontLinePlugin.groovy
+++ b/src/main/groovy/io/gatling/frontline/gradle/FrontLinePlugin.groovy
@@ -25,6 +25,7 @@ class FrontLinePlugin implements Plugin<Project> {
           "META-INF/LICENSE",
           "META-INF/MANIFEST.MF",
           "META-INF/versions/**",
+          "META-INF/maven/**",
           "**/*.SF",
           "**/*.DSA",
           "**/*.RSA"


### PR DESCRIPTION
Motivation:
We shipped all the maven files from the dependencies and fail to add the fatjar's ones.
As a result, Artifactory (and possibly others) automatic coordinate detection on deployment fails.

Modifications:
 * Exclude all files from /META-INF/maven

Result:
Cleaner fatjar